### PR TITLE
Update MailBoxes.php

### DIFF
--- a/src/Mailboxes/MailBoxes.php
+++ b/src/Mailboxes/MailBoxes.php
@@ -31,7 +31,7 @@ class MailBoxes
      */
     public function getMailBox(string $domain)
     {
-        return $this->MailCowAPI->get('get/mailbox/' . $domain);
+        return $this->MailCowAPI->get('get/mailbox/all/' . $domain);
     }
 
     /**


### PR DESCRIPTION
Currently, the API doesn't says, but If you want to retrieve all the mailboxes in a domain you need to call the endpoint `/get/mailbox/all/domainname.tld`

This appears in the API definition in the installed servers, not in the [Apiary info](https://mailcow.docs.apiary.io/#reference/mailboxes/update-mailbox/get-mailboxes), as you can see in this screenshot
![Captura de pantalla 2024-06-09 a la(s) 14 28 32](https://github.com/Exbil/mailcow-php-api/assets/62568995/b5400239-5f44-43aa-b04d-61921b4d5e18)
